### PR TITLE
Alter command's argument processing to match Unix norms.

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/release-engineering/backvendor/backvendor"
@@ -93,11 +94,20 @@ func showVendored(src *backvendor.GoSource) {
 }
 
 func main() {
+	log.SetFlags(0) // For typical stderr output of a program.
+
 	flag.Parse()
-	if flag.NArg() < 1 {
-		fmt.Printf("Usage: %s path\n", os.Args[0])
-		flag.PrintDefaults()
-		os.Exit(0)
+	flaw := ""
+	narg := flag.NArg()
+	if narg == 0 {
+		flaw = "missing path"
+	} else if narg != 1 {
+		flaw = fmt.Sprintf("only one path allowed: %q", flag.Arg(1))
+	}
+	if flaw != "" {
+		progName := filepath.Base(os.Args[0])
+		log.Printf("%s: %s\n", progName, flaw)
+		log.Fatalf("usage: %s path\n", progName)
 	}
 	src := backvendor.GoSource(flag.Arg(0))
 

--- a/main.go
+++ b/main.go
@@ -106,13 +106,13 @@ func main() {
 	cli.SetOutput(ioutil.Discard)
 	cli.Usage = func() {}
 
+	usageMsg := fmt.Sprintf("usage: %s [-help] [-importpath=toplevel] path", progName)
 	usage := func(flaw string) {
-		log.Printf("%s: %s\n", progName, flaw)
-		log.Fatalf("usage: %s [-help] [-importpath=toplevel] path\n", progName)
+		log.Fatalf("%s: %s\n%s\n", progName, flaw, usageMsg)
 	}
 	err := cli.Parse(os.Args[1:])
 	if err == flag.ErrHelp || *helpFlag { // Handle ‘-h’.
-		fmt.Printf("%s: help requested\n", progName)
+		fmt.Printf("%s: help requested\n%s\n", progName, usageMsg)
 		cli.SetOutput(os.Stdout)
 		flag.PrintDefaults()
 		os.Exit(0) // Not an error.

--- a/main.go
+++ b/main.go
@@ -95,8 +95,8 @@ func showVendored(src *backvendor.GoSource) {
 	}
 }
 
-func main() {
-	progName := filepath.Base(os.Args[0])
+func processArgs(args []string) backvendor.GoSource {
+	progName := filepath.Base(args[0])
 	log.SetFlags(0) // For typical stderr output of a program.
 
 	// Stop the default behaviour of printing errors and exiting.
@@ -110,7 +110,7 @@ func main() {
 	usage := func(flaw string) {
 		log.Fatalf("%s: %s\n%s\n", progName, flaw, usageMsg)
 	}
-	err := cli.Parse(os.Args[1:])
+	err := cli.Parse(args[1:])
 	if err == flag.ErrHelp || *helpFlag { // Handle ‘-h’.
 		fmt.Printf("%s: help requested\n%s\n", progName, usageMsg)
 		cli.SetOutput(os.Stdout)
@@ -128,8 +128,12 @@ func main() {
 	if narg != 1 {
 		usage(fmt.Sprintf("only one path allowed: %q", flag.Arg(1)))
 	}
-	src := backvendor.GoSource(flag.Arg(0))
 
+	return backvendor.GoSource(flag.Arg(0))
+}
+
+func main() {
+	src := processArgs(os.Args)
 	showTopLevel(&src)
 	showVendored(&src)
 }


### PR DESCRIPTION
Use stderr for all diagnostics rather than mixing with stdout.
Exit with a non-zero status on error.
Detail the nature of the error, e.g. user may not realise they're given
two arguments due to a space in the path.
Use the OS-independent basename of the executable in the error message.
Turn off log's default prefix of date and time for all log messages.