### PR TITLE
findImportPath: If os.Open errors, return it.

### DIFF
--- a/backvendor/vendored.go
+++ b/backvendor/vendored.go
@@ -84,6 +84,9 @@ func (src GoSource) findImportPath() (string, error) {
 			return nil
 		}
 		r, err := os.Open(path)
+		if err != nil {
+			return err
+		}
 		scanner := bufio.NewScanner(bufio.NewReader(r))
 		for scanner.Scan() {
 			line := scanner.Text()


### PR DESCRIPTION
Otherwise, nil is passed to bufio.NewReader that happily returns a new
reader that scans nothing.