### PR TITLE
pathStartsWith(): Simplify logic.

### DIFF
--- a/backvendor/vendored.go
+++ b/backvendor/vendored.go
@@ -25,12 +25,8 @@ import (
 )
 
 func pathStartsWith(dir, prefix string) bool {
-	plen := len(prefix)
-	if len(dir) <= plen {
-		return dir == prefix
-	}
-
-	return dir[:plen] == prefix && dir[plen] == filepath.Separator
+	return strings.HasPrefix(dir, prefix) &&
+		(len(dir) == len(prefix) || dir[len(prefix)] == filepath.Separator)
 }
 
 type vendoredSearch struct {


### PR DESCRIPTION
If dir starts with prefix then either it is prefix, or there's at least
one more byte available that can be tested to see if it's the path
separator.