### PR TITLE
vendored_test.go: A GoSource is now a struct, not a string.

### DIFF
--- a/backvendor/vendored_test.go
+++ b/backvendor/vendored_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestVendoredProjects(t *testing.T) {
-	src := GoSource("testdata/gosource")
+	src := NewGoSource("testdata/gosource")
 	expected := []string{
 		"github.com/eggs/ham",
 		"github.com/foo/bar",


### PR DESCRIPTION
Use NewGoSource().  Fixes 86ded979.