### PR TITLE
Include leading 'v' when creating pseudo-version

### DIFF
--- a/backvendor/workingtree.go
+++ b/backvendor/workingtree.go
@@ -206,7 +206,7 @@ func (wt *WorkingTree) PseudoVersion(rev string) (string, error) {
 				suffix = ".0."
 			}
 
-			version = ver.String()
+			version = "v" + ver.String()
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Tim Waugh <twaugh@redhat.com>