### PR TITLE
Replace ‘go-backvendor’ with ‘backvendor’.

### DIFF
--- a/backvendor/errors.go
+++ b/backvendor/errors.go
@@ -26,5 +26,5 @@ var ErrorNeedImportPath = errors.New("unable to determine import path")
 var ErrorVersionNotFound = errors.New("version not found")
 
 // ErrorUnknownVCS indicates the upstream version control system is not one of
-// those for which support is implemented in go-backvendor.
+// those for which support is implemented in backvendor.
 var ErrorUnknownVCS = errors.New("unknown VCS")

--- a/backvendor/workingtree.go
+++ b/backvendor/workingtree.go
@@ -40,7 +40,7 @@ type WorkingTree struct {
 // NewWorkingTree creates a local checkout of the version control
 // system for a Go project.
 func NewWorkingTree(project *vcs.RepoRoot) (*WorkingTree, error) {
-	dir, err := ioutil.TempDir("", "go-backvendor.")
+	dir, err := ioutil.TempDir("", "backvendor.")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It was still used in a documentation comment and the temporary-directory
name.