### PR TITLE
Rename ‘semver’-rooted identifiers to ‘version’.

### DIFF
--- a/backvendor/vendored.go
+++ b/backvendor/vendored.go
@@ -243,7 +243,7 @@ func DescribeProject(project *vcs.RepoRoot, root string) (*Reference, error) {
 	}
 
 	// First try matching against tags for semantic versions
-	tags, err := wt.SemVerTags()
+	tags, err := wt.VersionTags()
 	if err != nil {
 		return nil, err
 	}

--- a/backvendor/workingtree.go
+++ b/backvendor/workingtree.go
@@ -60,27 +60,27 @@ func (wt *WorkingTree) Close() error {
 	return os.RemoveAll(wt.Source.Path)
 }
 
-// SemVerTags returns a list of the semantic tags, i.e. those tags which are
-// parseable as semantic tags such as v1.1.0.
-func (wt *WorkingTree) SemVerTags() ([]string, error) {
+// VersionTags returns the tags that are parseable as semantic tags,
+// e.g. v1.1.0.
+func (wt *WorkingTree) VersionTags() ([]string, error) {
 	tags, err := wt.VCS.Tags(wt.Source.Path)
 	if err != nil {
 		return nil, err
 	}
-	semvers := make(semver.Collection, 0)
-	semverTags := make(map[*semver.Version]string)
+	versions := make(semver.Collection, 0)
+	versionTags := make(map[*semver.Version]string)
 	for _, tag := range tags {
 		v, err := semver.NewVersion(tag)
 		if err != nil {
 			continue
 		}
-		semvers = append(semvers, v)
-		semverTags[v] = tag
+		versions = append(versions, v)
+		versionTags[v] = tag
 	}
-	sort.Sort(sort.Reverse(semvers))
-	strTags := make([]string, len(semvers))
-	for i, v := range semvers {
-		strTags[i] = semverTags[v]
+	sort.Sort(sort.Reverse(versions))
+	strTags := make([]string, len(versions))
+	for i, v := range versions {
+		strTags[i] = versionTags[v]
 	}
 	return strTags, nil
 }


### PR DESCRIPTION
Discussion over whether capitalisation should be ‘semver’ or ‘semVer’
settled on moving away from using the name of the package to ‘version’,
as well-known semantic-version packages do in their API.