### PR TITLE
Add support for excluding files from matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Running
 ```
 $ backvendor -h
 backvendor: help requested
-usage: backvendor [-help] [-importpath=toplevel] [-deps=false] path
+usage: backvendor [OPTION]... PATH
   -deps
         show vendored dependencies (default true)
+  -exclude-from string
+        ignore glob patterns listed in provided file
   -help
         print help
   -importpath string
@@ -44,6 +46,16 @@ By default both the top-level project and its vendored dependencies are examined
 $ backvendor -deps=false -importpath github.com/example/name src
 ```
 
+If there are additional local files not expected to be part of the upstream version they can be excluded:
+```
+$ cat exclusions
+.git
+Dockerfile
+$ ls -d src/Dockerfile src/.git
+src/Dockerfile
+src/.git
+$ backvendor -exclude-from=exclusions src
+```
 
 Example output
 --------------

--- a/backvendor/vendored.go
+++ b/backvendor/vendored.go
@@ -131,14 +131,14 @@ type Reference struct {
 // DescribeProject attempts to identify the tag in the version control
 // system which corresponds to the project. Vendored files and files
 // whose names begin with "." are ignored.
-func DescribeProject(project *vcs.RepoRoot, root string) (*Reference, error) {
+func (src GoSource) DescribeProject(project *vcs.RepoRoot, root string) (*Reference, error) {
 	wt, err := NewWorkingTree(project)
 	if err != nil {
 		return nil, err
 	}
 	defer wt.Close()
 
-	hashes, err := NewFileHashes(wt.VCS.Cmd, root)
+	hashes, err := NewFileHashes(wt.VCS.Cmd, root, src.excludes)
 	if err != nil {
 		return nil, err
 	}
@@ -198,6 +198,6 @@ func DescribeProject(project *vcs.RepoRoot, root string) (*Reference, error) {
 // project.
 func (src GoSource) DescribeVendoredProject(project *vcs.RepoRoot) (*Reference, error) {
 	projectdir := filepath.Join(src.Vendor(), project.Root)
-	ref, err := DescribeProject(project, projectdir)
+	ref, err := src.DescribeProject(project, projectdir)
 	return ref, err
 }


### PR DESCRIPTION
New -exclude-from parameter.

Read globs from provided file and create a map of files to ignore.

Honour exclusions when looking for glide.yaml, looking for import comments, and hashing files.

Signed-off-by: Tim Waugh <twaugh@redhat.com>