### PR TITLE
Improve 'git describe' parsing

### DIFF
--- a/backvendor/workingtree.go
+++ b/backvendor/workingtree.go
@@ -167,41 +167,70 @@ func (wt *WorkingTree) timeFromRevision(rev string) (time.Time, error) {
 	return t, err
 }
 
+// gitReachableMatchingTag uses git to find a reachable tag from a
+// given revision rev. It limits the reachable tags using the glob
+// pattern match. If exact is true, the tag must be exactly at
+// revision rev, not just reachable (the output is parsed differently
+// in this case).
+func (wt *WorkingTree) gitReachableMatchingTag(rev, match string, exact bool) (string, error) {
+	argv := []string{"describe", "--tags", "--match=" + match}
+	if exact {
+		argv = append(argv, "--exact-match")
+	}
+	argv = append(argv, rev)
+	buf, err := wt.run(argv...)
+	output := strings.TrimSpace(buf.String())
+	if err != nil {
+		// Catch failures due to not finding an appropriate tag
+		switch {
+		// fatal: no tag exactly matches ...
+		// fatal: no tags can describe ...
+		// fatal: no names found, cannot describe anything.
+		// fatal: no annotated tags can describe ...
+		case strings.HasPrefix(output, "fatal: no tag"),
+			strings.HasPrefix(output, "fatal: no names"),
+			strings.HasPrefix(output, "fatal: No annotated tag"):
+			err = ErrorVersionNotFound
+		default:
+			os.Stderr.Write(buf.Bytes())
+		}
+		return "", err
+	}
+
+	if exact {
+		return output, nil
+	}
+
+	fields := strings.Split(output, "-")
+	if len(fields) < 3 {
+		cmd := strings.Join(append([]string{wt.VCS.Cmd}, argv...), " ")
+		return "", fmt.Errorf("expected at least two dashes: %s: %s", cmd, output)
+	}
+	return strings.Join(fields[:len(fields)-2], "-"), nil
+}
+
 // reachableTag returns the most recent reachable semver tag.
 func (wt *WorkingTree) reachableTag(rev string) (string, error) {
 	if wt.VCS.Cmd != vcsGit {
 		return "", ErrorUnknownVCS
 	}
 
-	var tag string
-	for _, match := range []string{"v[0-9]*", "[0-9]*"} {
-		buf, err := wt.run("describe", "--tags", "--match="+match, rev)
-		output := strings.TrimSpace(buf.String())
-		if err == nil {
-			tag = output
-			break
-		}
-
-		if output != "fatal: No names found, cannot describe anything." &&
-			!strings.HasPrefix(output, "fatal: No annotated tags can describe ") &&
-			!strings.HasPrefix(output, "fatal: No tags can describe ") {
-			os.Stderr.Write(buf.Bytes())
-			return "", err
+	for _, exact := range []bool{true, false} {
+		for _, match := range []string{"v[0-9]*", "[0-9]*"} {
+			tag, err := wt.gitReachableMatchingTag(rev, match, exact)
+			if err != nil {
+				if err == ErrorVersionNotFound {
+					continue
+				}
+				return "", err
+			}
+			if tag != "" {
+				return tag, nil
+			}
 		}
 	}
 
-	if tag == "" {
-		return "", ErrorVersionNotFound
-	}
-
-	log.Debugf("%s is described as %s", rev, tag)
-	fields := strings.Split(tag, "-")
-	if len(fields) < 3 {
-		// This matches a tag exactly (it must not be a semver tag)
-		return tag, nil
-	}
-	tag = strings.Join(fields[:len(fields)-2], "-")
-	return tag, nil
+	return "", ErrorVersionNotFound
 }
 
 func (wt *WorkingTree) PseudoVersion(rev string) (string, error) {


### PR DESCRIPTION
The output from 'git describe' varies depending on whether the found tag
is exactly at, or just reachable from, the given revision.

Handle this by running 'git describe' twice for each glob match: first
with '--exact-match' (in which case the output *is* the tag name), and
second without (in which case the output must be parsed to find the tag
name).

Signed-off-by: Tim Waugh <twaugh@redhat.com>