### PR TITLE
Split git-specific handling into a separate file

### DIFF
--- a/backvendor/filehash.go
+++ b/backvendor/filehash.go
@@ -49,9 +49,6 @@ type FileHashes struct {
 	// h is the Hasher used to create each FileHash
 	h Hasher
 
-	// root is the top level directory
-	root string
-
 	// hashes maps a relative filename to its FileHash
 	hashes map[string]FileHash
 }
@@ -62,7 +59,6 @@ type FileHashes struct {
 func NewFileHashes(h Hasher, root string, excludes map[string]struct{}) (*FileHashes, error) {
 	hashes := &FileHashes{
 		h:      h,
-		root:   root,
 		hashes: make(map[string]FileHash),
 	}
 	root = path.Clean(root)

--- a/backvendor/filehash_test.go
+++ b/backvendor/filehash_test.go
@@ -20,7 +20,11 @@ import (
 )
 
 func TestNewFileHashes(t *testing.T) {
-	hashes, err := NewFileHashes("git", "testdata/gosource", nil)
+	hasher, ok := NewHasher("git")
+	if !ok {
+		t.Fatal("git unknown to NewHasher")
+	}
+	hashes, err := NewFileHashes(hasher, "testdata/gosource", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,9 +33,6 @@ func TestNewFileHashes(t *testing.T) {
 	}
 	if hashes.root != "testdata/gosource" {
 		t.Fatalf("Incorrect hashes.root (%s)", hashes.root)
-	}
-	if hashes.vcsCmd != "git" {
-		t.Fatalf("Incorrect hashes.vcsCmd (%s)", hashes.vcsCmd)
 	}
 	emptyhash := FileHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")
 	expected := map[string]FileHash{
@@ -58,7 +59,11 @@ func TestNewFileHashes(t *testing.T) {
 func TestNewFileHashesExclude(t *testing.T) {
 	excludes := make(map[string]struct{})
 	excludes["testdata/gosource/ignored.go"] = struct{}{}
-	hashes, err := NewFileHashes("git", "testdata/gosource", excludes)
+	hasher, ok := NewHasher("git")
+	if !ok {
+		t.Fatal("git unknown to NewHasher")
+	}
+	hashes, err := NewFileHashes(hasher, "testdata/gosource", excludes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +89,11 @@ func TestNewFileHashesExclude(t *testing.T) {
 }
 
 func TestIsSubsetOf(t *testing.T) {
-	hashes, err := NewFileHashes("git", "testdata/gosource", nil)
+	hasher, ok := NewHasher("git")
+	if !ok {
+		t.Fatal("git unknown to NewHasher")
+	}
+	hashes, err := NewFileHashes(hasher, "testdata/gosource", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +103,7 @@ func TestIsSubsetOf(t *testing.T) {
 	}
 
 	other := &FileHashes{
-		vcsCmd: hashes.vcsCmd,
+		h:      hasher,
 		root:   hashes.root,
 		hashes: make(map[string]FileHash),
 	}

--- a/backvendor/filehash_test.go
+++ b/backvendor/filehash_test.go
@@ -31,9 +31,6 @@ func TestNewFileHashes(t *testing.T) {
 	if hashes == nil {
 		t.Fatal("NewFileHashes returned nil map")
 	}
-	if hashes.root != "testdata/gosource" {
-		t.Fatalf("Incorrect hashes.root (%s)", hashes.root)
-	}
 	emptyhash := FileHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")
 	expected := map[string]FileHash{
 		"ignored.go":                                 emptyhash,
@@ -104,7 +101,6 @@ func TestIsSubsetOf(t *testing.T) {
 
 	other := &FileHashes{
 		h:      hasher,
-		root:   hashes.root,
 		hashes: make(map[string]FileHash),
 	}
 	for k, v := range hashes.hashes {

--- a/backvendor/git.go
+++ b/backvendor/git.go
@@ -165,7 +165,6 @@ func (g *gitWorkingTree) FileHashesFromRef(ref string) (*FileHashes, error) {
 	}
 	return &FileHashes{
 		h:      hasher,
-		root:   g.anyWorkingTree.Source.Path,
 		hashes: fh,
 	}, nil
 }

--- a/backvendor/git.go
+++ b/backvendor/git.go
@@ -148,14 +148,10 @@ func (g *gitWorkingTree) FileHashesFromRef(ref string) (*FileHashes, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		fields := strings.Fields(line)
-		if len(fields) < 4 {
+		if len(fields) != 4 {
 			return nil, fmt.Errorf("line not understood: %s", line)
 		}
 
-		var mode uint32
-		if _, err = fmt.Sscanf(fields[0], "%o", &mode); err != nil {
-			return nil, err
-		}
 		fh[fields[3]] = FileHash(fields[2])
 	}
 

--- a/backvendor/git.go
+++ b/backvendor/git.go
@@ -1,0 +1,159 @@
+// Copyright (C) 2018 Tim Waugh
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package backvendor
+
+// This file contains methods specific to working with git.
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// gitRevisions returns all revisions in the git repository, using
+// 'git rev-list --all'.
+func (wt *WorkingTree) gitRevisions() ([]string, error) {
+	buf, err := wt.run("rev-list", "--all")
+	if err != nil {
+		os.Stderr.Write(buf.Bytes())
+		return nil, err
+	}
+	revisions := make([]string, 0)
+	output := bufio.NewScanner(buf)
+	for output.Scan() {
+		revisions = append(revisions, strings.TrimSpace(output.Text()))
+	}
+	return revisions, nil
+}
+
+// gitRevisionFromTag returns the commit hash for the given tag, using
+// 'git rev-parse ...'
+func (wt *WorkingTree) gitRevisionFromTag(tag string) (string, error) {
+	buf, err := wt.run("rev-parse", tag)
+	if err != nil {
+		os.Stderr.Write(buf.Bytes())
+		return "", err
+	}
+	rev := strings.TrimSpace(buf.String())
+	return rev, nil
+}
+
+// gitRevSync updates the working tree to reflect the tag or revision
+// ref, using 'git checkout ...'. The working tree must not have been
+// locally modified.
+func (wt *WorkingTree) gitRevSync(ref string) error {
+	buf, err := wt.run("checkout", ref)
+	if err != nil {
+		os.Stderr.Write(buf.Bytes())
+	}
+	return err
+}
+
+// gitTimeFromRevision returns the commit timestamp for the revision
+// rev, using 'git show -s --pretty=format:%cI ...'.
+func (wt *WorkingTree) gitTimeFromRev(rev string) (time.Time, error) {
+	var t time.Time
+	buf, err := wt.run("show", "-s", "--pretty=format:%cI", rev)
+	if err != nil {
+		return t, err
+	}
+
+	t, err = time.Parse(time.RFC3339, strings.TrimSpace(buf.String()))
+	return t, err
+}
+
+// gitReachableTag returns the most recent reachable semver tag, using
+// 'git describe --tags --match=...', with match globs for tags that
+// are likely to be semvers. It returns ErrorVersionNotFound if no
+// suitable tag is found.
+func (wt *WorkingTree) gitReachableTag(rev string) (string, error) {
+	var tag string
+	for _, match := range []string{"v[0-9]*", "[0-9]*"} {
+		buf, err := wt.run("describe", "--tags", "--match="+match, rev)
+		output := strings.TrimSpace(buf.String())
+		if err == nil {
+			tag = output
+			break
+		}
+
+		// Catch failures due to not finding an appropriate tag
+		output = strings.ToLower(output)
+		switch {
+		// fatal: no tag exactly matches ...
+		// fatal: no tags can describe ...
+		// fatal: no names found, cannot describe anything.
+		// fatal: no annotated tags can describe ...
+		case strings.HasPrefix(output, "fatal: no tag"),
+			strings.HasPrefix(output, "fatal: no names"),
+			strings.HasPrefix(output, "fatal: no annotated tag"):
+			err = ErrorVersionNotFound
+		default:
+			os.Stderr.Write(buf.Bytes())
+		}
+		return "", err
+	}
+
+	if tag == "" {
+		return "", ErrorVersionNotFound
+	}
+
+	log.Debugf("%s is described as %s", rev, tag)
+	fields := strings.Split(tag, "-")
+	if len(fields) < 3 {
+		// This matches a tag exactly (it must not be a semver tag)
+		return tag, nil
+	}
+	tag = strings.Join(fields[:len(fields)-2], "-")
+	return tag, nil
+}
+
+// gitFileHashesFromRef parses the output of 'git ls-tree -r' to
+// return the file hashes for the given tag or revision ref.
+func (wt *WorkingTree) gitFileHashesFromRef(ref string) (*FileHashes, error) {
+	buf, err := wt.run("ls-tree", "-r", ref)
+	if err != nil {
+		if strings.HasPrefix(buf.String(), "fatal: Not a valid object name ") {
+			// This is a branch name, not a tag name
+			return nil, ErrorInvalidRef
+		}
+
+		os.Stderr.Write(buf.Bytes())
+		return nil, err
+	}
+	fh := make(map[string]FileHash)
+	scanner := bufio.NewScanner(buf)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			return nil, fmt.Errorf("line not understood: %s", line)
+		}
+
+		var mode uint32
+		if _, err = fmt.Sscanf(fields[0], "%o", &mode); err != nil {
+			return nil, err
+		}
+		fh[fields[3]] = FileHash(fields[2])
+	}
+
+	return &FileHashes{
+		vcsCmd: vcsGit,
+		root:   wt.Source.Path,
+		hashes: fh,
+	}, nil
+}

--- a/backvendor/git_test.go
+++ b/backvendor/git_test.go
@@ -82,9 +82,11 @@ func TestHelper(t *testing.T) {
 func TestGitRevisions(t *testing.T) {
 	defer mockExecCommand()()
 
-	wt := WorkingTree{
-		Source: &GoSource{},
-		VCS:    vcs.ByCmd("git"),
+	wt := gitWorkingTree{
+		anyWorkingTree: anyWorkingTree{
+			Source: &GoSource{},
+			VCS:    vcs.ByCmd("git"),
+		},
 	}
 
 	expectedRevs := []string{
@@ -112,9 +114,11 @@ func TestGitRevisions(t *testing.T) {
 func TestGitRevisionsError(t *testing.T) {
 	defer mockExecCommand()()
 
-	wt := WorkingTree{
-		Source: &GoSource{},
-		VCS:    vcs.ByCmd("git"),
+	wt := gitWorkingTree{
+		anyWorkingTree: anyWorkingTree{
+			Source: &GoSource{},
+			VCS:    vcs.ByCmd("git"),
+		},
 	}
 
 	mockedStderr = "fatal: not a git repository\n"

--- a/backvendor/git_test.go
+++ b/backvendor/git_test.go
@@ -1,0 +1,127 @@
+// Copyright (C) 2018 Tim Waugh
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package backvendor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/vcs"
+)
+
+const (
+	envHelper     = "GO_WANT_HELPER_PROCESS"
+	envStdout     = "STDOUT"
+	envStderr     = "STDERR"
+	envExitStatus = "EXIT_STATUS"
+)
+
+var mockedExitStatus int
+var mockedStdout, mockedStderr string
+
+// Capture exec.Command calls via execCommand and make them run our
+// fake version instead. This returns a function which the caller
+// should defer a call to in order to reset execCommand.
+func mockExecCommand() func() {
+	execCommand = fakeExecCommand
+
+	// Reset it afterwards
+	return func() {
+		execCommand = exec.Command
+		mockedExitStatus = 0
+		mockedStdout = ""
+		mockedStderr = ""
+	}
+}
+
+// Run this test binary (again!) but transfer control immediately to
+// TestHelper, telling it how to act.
+func fakeExecCommand(command string, args ...string) *exec.Cmd {
+	testBinary := os.Args[0]
+	opts := []string{"-test.run=TestHelper", "--", command}
+	opts = append(opts, args...)
+	cmd := exec.Command(testBinary, opts...)
+	cmd.Env = []string{
+		envHelper + "=1",
+		envStdout + "=" + mockedStdout,
+		envStderr + "=" + mockedStderr,
+		envExitStatus + "=" + strconv.Itoa(mockedExitStatus),
+	}
+	return cmd
+}
+
+// This runs in its own process (see fakeExecCommand) and mocks the
+// command being run.
+func TestHelper(t *testing.T) {
+	if os.Getenv(envHelper) != "1" {
+		return
+	}
+	fmt.Print(os.Getenv(envStdout))
+	fmt.Fprint(os.Stderr, os.Getenv(envStderr))
+	exit, _ := strconv.Atoi(os.Getenv(envExitStatus))
+	os.Exit(exit)
+}
+
+func TestGitRevisions(t *testing.T) {
+	defer mockExecCommand()()
+
+	wt := WorkingTree{
+		Source: &GoSource{},
+		VCS:    vcs.ByCmd("git"),
+	}
+
+	expectedRevs := []string{
+		"d4c3dbfa77a74ae238e401d5d2197b45f30d8513",
+		"a2176f4275f92ceddb47cff1e363313156124bf6",
+	}
+	mockedStdout = strings.Join(expectedRevs, "\n") + "\n"
+
+	revs, err := wt.Revisions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(revs) != len(expectedRevs) {
+		t.Fatalf("wrong number of revisions: got %d, want %d",
+			len(revs), len(expectedRevs))
+	}
+	for i, rev := range expectedRevs {
+		if revs[i] != rev {
+			t.Fatalf("unexpected revisions: got %v, want %v",
+				revs, expectedRevs)
+		}
+	}
+}
+
+func TestGitRevisionsError(t *testing.T) {
+	defer mockExecCommand()()
+
+	wt := WorkingTree{
+		Source: &GoSource{},
+		VCS:    vcs.ByCmd("git"),
+	}
+
+	mockedStderr = "fatal: not a git repository\n"
+	mockedExitStatus = 128
+
+	_, err := wt.Revisions()
+	if err == nil {
+		t.Fatal("git failure was not reported")
+	}
+}

--- a/backvendor/workingtree.go
+++ b/backvendor/workingtree.go
@@ -33,6 +33,8 @@ import (
 	"golang.org/x/tools/go/vcs"
 )
 
+var execCommand = exec.Command
+
 // A WorkingTree is a local checkout of Go source code, and
 // information about the version control system it came from.
 type WorkingTree struct {
@@ -96,7 +98,7 @@ func (wt *WorkingTree) VersionTags() ([]string, error) {
 // run runs the VCS command with the provided args
 // and returns a bytes.Buffer.
 func (wt *WorkingTree) run(args ...string) (*bytes.Buffer, error) {
-	p := exec.Command(wt.VCS.Cmd, args...)
+	p := execCommand(wt.VCS.Cmd, args...)
 	var buf bytes.Buffer
 	p.Stdout = &buf
 	p.Stderr = &buf

--- a/backvendor/workingtree_test.go
+++ b/backvendor/workingtree_test.go
@@ -27,9 +27,11 @@ func TestStripImportCommentPackage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wt := &WorkingTree{
-		Source: src,
-		VCS:    vcs.ByCmd("git"),
+	wt := &gitWorkingTree{
+		anyWorkingTree: anyWorkingTree{
+			Source: src,
+			VCS:    vcs.ByCmd("git"),
+		},
 	}
 
 	w := bytes.NewBuffer(nil)
@@ -51,9 +53,11 @@ func TestStripImportCommentNewline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wt := &WorkingTree{
-		Source: src,
-		VCS:    vcs.ByCmd("git"),
+	wt := &gitWorkingTree{
+		anyWorkingTree: anyWorkingTree{
+			Source: src,
+			VCS:    vcs.ByCmd("git"),
+		},
 	}
 
 	w := bytes.NewBuffer(nil)


### PR DESCRIPTION
The Revisions method calls the new gitRevisions method when the
current vcs is git, and so on for other methods.

Signed-off-by: Tim Waugh <twaugh@redhat.com>