### PR TITLE
Use version from glide.lock, if available

### DIFF
--- a/backvendor/glide/glide.go
+++ b/backvendor/glide/glide.go
@@ -1,0 +1,70 @@
+package glide
+
+import (
+	"gopkg.in/yaml.v2"
+	"os"
+	"path/filepath"
+)
+
+type glideLock struct {
+	Imports []Import `json:"imports"`
+}
+
+type glideConf struct {
+	Package string `json:"package"`
+	Import  []struct {
+		Package string
+		Repo    string `json:"omitempty"`
+	}
+}
+
+type Import struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Repo    string `json:"repo"`
+}
+
+type Glide struct {
+	Package string
+	Imports []Import
+}
+
+// LoadGlide tries to load glide.lock and glide.conf and extract import information.
+// In case no glide.lock is present, it will use the import information from glide.yaml.
+func LoadGlide(projectRoot string) (*Glide, error) {
+	lockImports := []Import{}
+	lockFile, err := os.Open(filepath.Join(projectRoot, "glide.lock"))
+	if err == nil {
+		defer lockFile.Close()
+		lock := glideLock{}
+		if err != nil {
+			return nil, err
+		}
+		err = yaml.NewDecoder(lockFile).Decode(&lock)
+		if err != nil {
+			return nil, err
+		}
+		lockImports = lock.Imports
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	confFile, err := os.Open(filepath.Join(projectRoot, "glide.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	defer confFile.Close()
+	conf := glideConf{}
+	err = yaml.NewDecoder(confFile).Decode(&conf)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(lockImports) == 0 {
+		for _, imp := range conf.Import {
+			lockImports = append(lockImports, Import{Name: imp.Package, Repo: imp.Repo})
+		}
+	}
+
+	return &Glide{Imports: lockImports, Package: conf.Package}, nil
+}

--- a/backvendor/glide/glide_test.go
+++ b/backvendor/glide/glide_test.go
@@ -1,0 +1,24 @@
+package glide
+
+import (
+	"testing"
+)
+
+func TestGlideFalse(t *testing.T) {
+	glide, err := LoadGlide("../testdata/glide/")
+	if err != nil {
+		t.Fatal("failed to load the lock file", err)
+	}
+	if glide.Imports[0].Name != "github.com/pborman/uuid" {
+		t.Fatalf("expected '%v', got '%v'", "github.com/pborman/uuid", glide.Imports[0].Name)
+	}
+	if glide.Imports[0].Version != "ca53cad383cad2479bbba7f7a1a05797ec1386e4" {
+		t.Fatalf("expected '%v', got '%v'", "ca53cad383cad2479bbba7f7a1a05797ec1386e4", glide.Imports[0].Version)
+	}
+	if len(glide.Imports) != 2 {
+		t.Fatalf("expected '%v', got '%v'", 2, len(glide.Imports))
+	}
+	if glide.Package != "github.com/release-engineering/backvendor/testdata/glide" {
+		t.Fatalf("expected '%v', got '%v'", "github.com/release-engineering/backvendor/testdata/glide", glide.Package)
+	}
+}

--- a/backvendor/gosource_test.go
+++ b/backvendor/gosource_test.go
@@ -53,6 +53,26 @@ func TestGodepTrue(t *testing.T) {
 	}
 }
 
+func TestGlideFalse(t *testing.T) {
+	src, err := NewGoSource("testdata/godep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Package == "github.com/release-engineering/backvendor/testdata/glide" {
+		t.Fatal("usesGlide")
+	}
+}
+
+func TestGlideTrue(t *testing.T) {
+	src, err := NewGoSource("testdata/glide")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Package != "github.com/release-engineering/backvendor/testdata/glide" {
+		t.Fatal("usesGodep")
+	}
+}
+
 func TestImportPathFromFilepath(t *testing.T) {
 	tests := []struct {
 		filePath, importPath string

--- a/backvendor/testdata/glide/glide.lock
+++ b/backvendor/testdata/glide/glide.lock
@@ -1,0 +1,5 @@
+imports:
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+- name: github.com/spf13/pflag
+  version: 583c0c0531f06d5278b7d917446061adc344b5cd

--- a/backvendor/testdata/glide/glide.yaml
+++ b/backvendor/testdata/glide/glide.yaml
@@ -1,0 +1,1 @@
+package: github.com/release-engineering/backvendor/testdata/glide

--- a/backvendor/testdata/glide/main.go
+++ b/backvendor/testdata/glide/main.go
@@ -1,0 +1,1 @@
+package glide

--- a/backvendor/testdata/glide/vendor/github.com/pborman/uuid/test.go
+++ b/backvendor/testdata/glide/vendor/github.com/pborman/uuid/test.go
@@ -1,0 +1,1 @@
+package uuid

--- a/backvendor/testdata/glide/vendor/github.com/spf13/pflag/test.go
+++ b/backvendor/testdata/glide/vendor/github.com/spf13/pflag/test.go
@@ -1,0 +1,1 @@
+package pflag

--- a/backvendor/workingtree.go
+++ b/backvendor/workingtree.go
@@ -94,7 +94,7 @@ type anyWorkingTree struct {
 
 // NewWorkingTree creates a local checkout of the version control
 // system for a Go project.
-func NewWorkingTree(project *vcs.RepoRoot) (WorkingTree, error) {
+func NewWorkingTree(project *RepoRoot) (WorkingTree, error) {
 	dir, err := ioutil.TempDir("", "backvendor.")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Extract the package version from `glide.lock` and use it to determine the commit which most-likely matches the checked out vendor sources if the project uses glide.

Right now `backvendor` just falls back to its usual heuristic if there is no match. This could be extended to provide warnings that `glide.lock` and the `vendor` content are not in sync.

@twaugh  not sure if you are interested in a change like this.