### PR TITLE
Handle 'not a tree object' error from git

### DIFF
--- a/backvendor/git.go
+++ b/backvendor/git.go
@@ -142,8 +142,13 @@ func (g *gitWorkingTree) FileHashesFromRef(ref, subPath string) (*FileHashes, er
 	}
 	buf, err := g.anyWorkingTree.run(args...)
 	if err != nil {
-		if strings.HasPrefix(buf.String(), "fatal: Not a valid object name ") {
+		output := strings.ToLower(buf.String())
+		switch {
+		case strings.HasPrefix(output, "fatal: not a valid object name "):
 			// This is a branch name, not a tag name
+			return nil, ErrorInvalidRef
+		case strings.HasPrefix(output, "fatal: not a tree object"):
+			// This ref is not present in the repo
 			return nil, ErrorInvalidRef
 		}
 

--- a/backvendor/git_test.go
+++ b/backvendor/git_test.go
@@ -273,6 +273,18 @@ func TestGitErrors(t *testing.T) {
 		t.Error("FileHashesFromRef: git failure was not reported")
 	}
 
+	mockedStderr = "fatal: Not a valid object name 012345\n"
+	_, err = wt.FileHashesFromRef("012345", "")
+	if err != ErrorInvalidRef {
+		t.Error("FileHashesFromRef: missing ErrorInvalidRef")
+	}
+
+	mockedStderr = "fatal: not a tree object\n"
+	_, err = wt.FileHashesFromRef("012345", "")
+	if err != ErrorInvalidRef {
+		t.Error("FileHashesFromRef: missing ErrorInvalidRef")
+	}
+
 	hasher, ok := NewHasher(vcsGit)
 	if !ok {
 		t.Fatal("unknown hasher")


### PR DESCRIPTION
Signed-off-by: Tim Waugh <twaugh@redhat.com>