### PR TITLE
Unknown Version Handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,10 +103,6 @@ func showTopLevel(tmpl *template.Template, src *retrodep.GoSource) *retrodep.Ref
 		log.Fatalf("%s: %s", src.Path, err)
 	}
 
-	if err != nil {
-		return nil
-	}
-
 	return project
 }
 

--- a/main.go
+++ b/main.go
@@ -51,9 +51,9 @@ var exitFirst = flag.Bool("x", false, "exit on the first failure")
 var errorShown = false
 var usage func(string)
 
-func displayUnknown(tmpl *template.Template, topLevelMarker string, ref *retrodep.Reference, root string) {
+func displayUnknown(tmpl *template.Template, topLevelMarker string, ref *retrodep.Reference, projectRoot string) {
 	if ref == nil || *templateArg != "" {
-		fmt.Printf("%s%s ?\n", topLevelMarker, root)
+		fmt.Printf("%s%s ?\n", topLevelMarker, projectRoot)
 	} else {
 		display(tmpl, topLevelMarker, ref)
 	}

--- a/main.go
+++ b/main.go
@@ -47,8 +47,12 @@ var exitFirst = flag.Bool("x", false, "exit on the first failure")
 var errorShown = false
 var usage func(string)
 
-func displayUnknown(name string) {
-	fmt.Printf("%s ?\n", name)
+func displayUnknown(tmpl *template.Template, name string, ref *retrodep.Reference, root string) {
+	if ref == nil || *templateArg != "" {
+		fmt.Printf("%s%s ?\n", name, root)
+	} else {
+		display(tmpl, name, ref)
+	}
 	if !errorShown {
 		errorShown = true
 		fmt.Fprintln(os.Stderr, "error: not all versions identified")
@@ -92,7 +96,7 @@ func showTopLevel(tmpl *template.Template, src *retrodep.GoSource) *retrodep.Ref
 	}
 	switch err {
 	case retrodep.ErrorVersionNotFound:
-		displayUnknown(topLevelMarker + main.Root)
+		displayUnknown(tmpl, topLevelMarker, project, main.Root)
 	case nil:
 		display(tmpl, topLevelMarker, project)
 	default:
@@ -125,7 +129,7 @@ func showVendored(tmpl *template.Template, src *retrodep.GoSource, top *retrodep
 		vp, err := src.DescribeVendoredProject(project, top)
 		switch err {
 		case retrodep.ErrorVersionNotFound:
-			displayUnknown(project.Root)
+			displayUnknown(tmpl, "", vp, project.Root)
 		case nil:
 			display(tmpl, "", vp)
 		default:

--- a/main.go
+++ b/main.go
@@ -51,11 +51,11 @@ var exitFirst = flag.Bool("x", false, "exit on the first failure")
 var errorShown = false
 var usage func(string)
 
-func displayUnknown(tmpl *template.Template, name string, ref *retrodep.Reference, root string) {
+func displayUnknown(tmpl *template.Template, topLevelMarker string, ref *retrodep.Reference, root string) {
 	if ref == nil || *templateArg != "" {
-		fmt.Printf("%s%s ?\n", name, root)
+		fmt.Printf("%s%s ?\n", topLevelMarker, root)
 	} else {
-		display(tmpl, name, ref)
+		display(tmpl, topLevelMarker, ref)
 	}
 	if !errorShown {
 		errorShown = true
@@ -66,9 +66,9 @@ func displayUnknown(tmpl *template.Template, name string, ref *retrodep.Referenc
 	}
 }
 
-func display(tmpl *template.Template, name string, ref *retrodep.Reference) {
+func display(tmpl *template.Template, topLevelMarker string, ref *retrodep.Reference) {
 	var builder strings.Builder
-	builder.WriteString(name)
+	builder.WriteString(topLevelMarker)
 	err := tmpl.Execute(&builder, ref)
 	if err != nil {
 		log.Fatalf("Error generating output. %s ", err)

--- a/main.go
+++ b/main.go
@@ -30,7 +30,11 @@ import (
 	"github.com/release-engineering/retrodep/retrodep"
 )
 
-const defaultTemplate string = "{{if .TopPkg}}{{.TopPkg}}:{{.TopVer}}/{{end}}{{.Pkg}}:{{.Ver}}"
+const defaultTemplate string = `
+  {{- if .TopPkg -}}
+	{{.TopPkg}}:{{or .TopVer "?"}}/
+  {{- end -}}
+  {{.Pkg}}:{{or .Ver "?"}}`
 
 var log = logging.MustGetLogger("retrodep")
 

--- a/main_test.go
+++ b/main_test.go
@@ -53,15 +53,21 @@ func captureStdout(t *testing.T) (r io.Reader, reset func()) {
 
 func TestDisplayUnknown(t *testing.T) {
 	tcs := []struct {
-		name     string
-		ref      *retrodep.Reference
-		template string
-		expected string
+		name        string
+		ref         *retrodep.Reference
+		templateArg string
+		expected    string
 	}{
 		{
-			"nil ref",
+			"nil ref, empty templateArg",
 			nil,
 			"",
+			"*example.com/foo ?\n",
+		},
+		{
+			"with ref, non-zero templateArg",
+			&retrodep.Reference{Pkg: "example.com/foo"},
+			"filled templateArg",
 			"*example.com/foo ?\n",
 		},
 	}
@@ -70,9 +76,9 @@ func TestDisplayUnknown(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			*templateArg = tc.template
+			*templateArg = tc.templateArg
 			r, reset := captureStdout(t)
-			displayUnknown(nil, "*", nil, "example.com/foo")
+			displayUnknown(nil, "*", tc.ref, "example.com/foo")
 			reset()
 			output, err := ioutil.ReadAll(r)
 			if err != nil {

--- a/retrodep/vendored.go
+++ b/retrodep/vendored.go
@@ -343,6 +343,13 @@ func (src GoSource) DescribeProject(
 		topver = top.Ver
 	}
 
+	ref = &Reference{
+		TopPkg: toppkg,
+		TopVer: topver,
+		Pkg:    project.Root,
+		Repo:   project.Repo,
+	}
+
 	// First try to match against a specific version, if specified
 	if project.Version != "" {
 		matches, err := matchFromRefs(strip, hashes, wt,
@@ -357,14 +364,8 @@ func (src GoSource) DescribeProject(
 				return nil, err
 			}
 
-			ref = &Reference{
-				TopPkg: toppkg,
-				TopVer: topver,
-				Pkg:    project.Root,
-				Repo:   project.Repo,
-				Rev:    match,
-				Ver:    ver,
-			}
+			ref.Rev = match
+			ref.Ver = ver
 			return ref, nil
 		case ErrorVersionNotFound:
 			// No match, carry on
@@ -390,15 +391,9 @@ func (src GoSource) DescribeProject(
 			return nil, err
 		}
 
-		ref = &Reference{
-			TopPkg: toppkg,
-			TopVer: topver,
-			Pkg:    project.Root,
-			Repo:   project.Repo,
-			Tag:    match,
-			Rev:    rev,
-			Ver:    match,
-		}
+		ref.Tag = match
+		ref.Rev = rev
+		ref.Ver = match
 		return ref, nil
 	case ErrorVersionNotFound:
 		// No match, carry on
@@ -425,14 +420,8 @@ func (src GoSource) DescribeProject(
 		return ref, err
 	}
 
-	ref = &Reference{
-		TopPkg: toppkg,
-		TopVer: topver,
-		Pkg:    project.Root,
-		Repo:   project.Repo,
-		Rev:    rev,
-		Ver:    ver,
-	}
+	ref.Rev = rev
+	ref.Ver = ver
 	return ref, nil
 }
 


### PR DESCRIPTION
Adds templating support (with `-o` argument) in case when a version of toplevel or vendored package is not matched. Unknown version is by default marked with `?`.

Example (with unknown toplevel version):
```
github.com/rogpeppe/godef:?
github.com/rogpeppe/godef:?/9fans.net/go:v0.0.0-0.20181112111441-237454027057
github.com/rogpeppe/godef:?/golang.org/x/tools:v0.0.0-0.20181130195746-895048a75ecf
```