### PR TITLE
template: "space" separator for toplevel pkg

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,8 +32,7 @@ import (
 
 const defaultTemplate string = `
   {{- if .TopPkg -}}
-	{{.TopPkg}}:{{or .TopVer "?"}}/
-  {{- end -}}
+	{{.TopPkg}}:{{or .TopVer "?"}} {{ end -}}
   {{.Pkg}}:{{or .Ver "?"}}`
 
 var log = logging.MustGetLogger("retrodep")


### PR DESCRIPTION
Use `>` (greater-than symbol) as a separator for toplevel package and vendored package, to allow easier parsing. Previously used slash collides with package names.

EDIT: Separator changed to space, based on the suggestions.