### PR TITLE
Print results even if errors are encountered on some repos

### DIFF
--- a/retrodep/vendored.go
+++ b/retrodep/vendored.go
@@ -55,7 +55,8 @@ func processVendoredSource(src *GoSource, search *vendoredSearch, pth string) er
 	thisImport := filepath.ToSlash(filepath.Dir(rel))
 	repoPath, err := src.RepoPathForImportPath(thisImport)
 	if err != nil {
-		return err
+		log.Error(err)
+		return nil
 	}
 
 	// The project name is relative to the vendor dir


### PR DESCRIPTION
Currently if an error is encountered on a repo, retrodep will
just exit (log.Fatal is called).
This patch changes this to just printing the error, and then
the results for correct results.