### PR TITLE
Failed repo version will be printed as ?

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,6 +141,10 @@ func showVendored(tmpl *template.Template, src *retrodep.GoSource, top *retrodep
 	// Describe each vendored project
 	for _, repo := range repos {
 		project := vendored[repo]
+		if project.Err != nil {
+			displayUnknown(tmpl, "", &retrodep.Reference{TopPkg: top.Pkg, TopVer: top.Ver, Pkg: repo}, repo)
+			continue
+		}
 		wt, err := newWorkingTree(project.Root, &project.RepoRoot)
 		if err != nil {
 			log.Fatalf("%s: %s", project.Root, err)

--- a/retrodep/gosource.go
+++ b/retrodep/gosource.go
@@ -44,6 +44,8 @@ type RepoPath struct {
 	SubPath string
 
 	Version string
+
+	Err error
 }
 
 var log = logging.MustGetLogger("retrodep")

--- a/retrodep/vendored.go
+++ b/retrodep/vendored.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
+	"golang.org/x/tools/go/vcs"
 )
 
 func pathStartsWith(dir, prefix string) bool {
@@ -55,7 +56,8 @@ func processVendoredSource(src *GoSource, search *vendoredSearch, pth string) er
 	thisImport := filepath.ToSlash(filepath.Dir(rel))
 	repoPath, err := src.RepoPathForImportPath(thisImport)
 	if err != nil {
-		return err
+		search.vendored[thisImport] = &RepoPath{RepoRoot: vcs.RepoRoot{Root: thisImport}, Err: err}
+		return nil
 	}
 
 	// The project name is relative to the vendor dir


### PR DESCRIPTION
If parsing of a repo fails, retrodep was exiting without
printing anything.
With this patch, retrodep will print all packages, printing
the version for failed packages as ?