### PR TITLE
retrodiff: exclude *.bzl and *.bazel

### DIFF
--- a/extras/retrodiff
+++ b/extras/retrodiff
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2019 Tim Waugh
+# Copyright (C) 2019, 2020 Tim Waugh
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -60,9 +60,41 @@ additional-tags
 content_sets.yml
 container.yaml
 .oit
-OWNERS
 public
 scripts
+OWNERS
+*.bazel
+*.bzl
+*/*.bazel
+*/*.bzl
+*/*/*.bazel
+*/*/*.bzl
+*/*/*/*.bazel
+*/*/*/*.bzl
+*/*/*/*/*.bazel
+*/*/*/*/*.bzl
+*/*/*/*/*/*.bazel
+*/*/*/*/*/*.bzl
+*/*/*/*/*/*/*.bazel
+*/*/*/*/*/*/*.bzl
+*/*/*/*/*/*/*/*.bazel
+*/*/*/*/*/*/*/*.bzl
+*/*/*/*/*/*/*/*/*.bazel
+*/*/*/*/*/*/*/*/*.bzl
+*/*/*/*/*/*/*/*/*/*.bazel
+*/*/*/*/*/*/*/*/*/*.bzl
+*/*/*/*/*/*/*/*/*/*/*.bazel
+*/*/*/*/*/*/*/*/*/*/*.bzl
+*/*/*/*/*/*/*/*/*/*/*/*.bazel
+*/*/*/*/*/*/*/*/*/*/*/*.bzl
+*/*/*/*/*/*/*/*/*/*/*/*/*.bazel
+*/*/*/*/*/*/*/*/*/*/*/*/*.bzl
+*/*/*/*/*/*/*/*/*/*/*/*/*/*.bazel
+*/*/*/*/*/*/*/*/*/*/*/*/*/*.bzl
+*/*/*/*/*/*/*/*/*/*/*/*/*/*/*.bazel
+*/*/*/*/*/*/*/*/*/*/*/*/*/*/*.bzl
+*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*.bazel
+*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*.bzl
 EOF
     done) <<<"$MODULES"
 fi


### PR DESCRIPTION
Signed-off-by: Tim Waugh <twaugh@redhat.com>